### PR TITLE
fix: github auth poling

### DIFF
--- a/GitHubAuthentication/GitHubAcessTokenProvider.cs
+++ b/GitHubAuthentication/GitHubAcessTokenProvider.cs
@@ -31,7 +31,7 @@ public class GitHubAccessTokenProvider : IAccessTokenProvider
 				var tokenResponse = await GetTokenAsync(deviceCodeResponse, cancellationToken);
 				if(tokenResponse != null)
 					return tokenResponse;
-				await Task.Delay(TimeSpan.FromSeconds(deviceCodeResponse.IntervalInSeconds), cancellationToken);
+				await Task.Delay(TimeSpan.FromSeconds(deviceCodeResponse.IntervalInSeconds + 1), cancellationToken);
 			}
 			return null;
 		}, cancellationToken);


### PR DESCRIPTION
Add 1 second to the returned polling interval when polling github for an auth response for the device code flow to avoid getting slow_down errros